### PR TITLE
Rename to "Resources", refresh content for TIDES Briefing 6/2/26

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,30 @@
-# TIDES Awesome List
+# TIDES Resources
 
-## Data Specification and Documentation
+## Implementation & Technical Architecture Guidance 
 
-- [TIDES Website](https://tides-transit.org/): Official website for TIDES project.
-- [TIDES Specification](https://github.com/TIDES-transit/TIDES): GitHub repository describing TIDES data.
+- *COMING SOON* Getting Started: High-level guidance for getting started with TIDES
+- *COMING SOON* Implementation Guide: Detailed resource walking through implementation considerations based on data source and technical requirements
+- [TIDES Architecture Framework](https://docs.google.com/document/d/12NAwIuVvaaQQSQVtAlMhhhLJ1FnziX3G4KEI68B-et0): A framework for approaching the data infrastructure setup to support a TIDES implementation
 
-## Data Conversion
+## Use Case Profiles
 
+- *COMING SOON* National Transit Database (NTD) Reporting Use Case Profile: How TIDES can support NTD reporting requirements
+- *COMING SOON* On-time Performance Use Case Profile: How TIDES can support on-time performance (OTP) reporting and analysis
+
+## Implementation and Code Examples
+
+- [tides-implementations](https://github.com/TIDES-transit/tides-implementations): A repository of TIDES implementation examples
+   - *COMING SOON* WMATA SDH writeup and [wmata/sdh-open-source](https://github.com/TIDES-transit/tides-implementations/tree/main/agencies/wmata/sdh-open-source): A writeup and the open-sourced code from WMATA's SMART Data Hub TIDES implementation
+   - *COMING SOON* Cal-ITP code: The code from Cal-ITP's GTFS-RT-to-TIDES conversion
+   - *COMING SOON* Mountain Line (Missoula) code: The code from Missoula's TIDES implementation 
 - [evansiroky/gtfs-rt-to-tides](https://github.com/evansiroky/gtfs-rt-to-tides): A set of scripts to turn collected GTFS-RT into TIDES data
 
 ## Sample Data
 
+- *COMING SOON* Cal-ITP sample data: Description of how to access Cal-ITP's public sample TIDES data
 - [evansiroky/magellan-elcano-tides](https://github.com/evansiroky/magellan-elcano-tides): An example implementation of the TIDES Standard that describes the Magellan–Elcano expedition
+
+## Official Specification and Documentation
+
+- [TIDES Website](https://tides-transit.org/): Official website for TIDES project.
+- [TIDES Specification](https://github.com/TIDES-transit/TIDES): GitHub repository describing TIDES data.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@
 - *COMING SOON* Cal-ITP sample data: Description of how to access Cal-ITP's public sample TIDES data
 - [evansiroky/magellan-elcano-tides](https://github.com/evansiroky/magellan-elcano-tides): An example implementation of the TIDES Standard that describes the Magellan–Elcano expedition
 
+## Slide Decks and Presentations
+
+- ["TIDES: Transit Data Pipelines, Not Silos" (TransportationCamp DC, January 2026)](https://drive.google.com/file/d/1FeTWyRKnuIdj-SwxEiO8-xtUZQ_E0XzD/view): Introduction to TIDES.
+- ["Introducing the Common Transit Operations Data Framework" (Transportation Research Board Annual Meeting, January 2026)](https://drive.google.com/file/d/1bZemmulpLhGzq1zKS-kXeg8E_Xvh4Hyl/view?usp=drive_link): Overview of proposed data architecture/data infrastructure approach for working with TIDES data.
+
 ## Official Specification and Documentation
 
 - [TIDES Website](https://tides-transit.org/): Official website for TIDES project.


### PR DESCRIPTION
Based on conversation with @chrisyamas, this PR:

* Re-titles the Markdown file to "Resources" pending associated change on tides-transit.org 
* Adds new sections & reorders to place more emphasis on implementation resources and sample code
* Adds placeholders for in-flight resources & links to live architecture framework & WMATA open repo 

Question:
* Are we good with the included decks as a starting point? And is linking to PDFs rather than Google Slides ok?